### PR TITLE
Nerve regeneration presets

### DIFF
--- a/json/binaurals.json
+++ b/json/binaurals.json
@@ -189,6 +189,13 @@
       "data_id":"h18zpydhk"
    },
    {
+      "data_name":"2 hz Binaural Beats over Solfeggio 285 hz",
+      "data_description":"Nerve regeneration [Phase 1]",
+      "data_start":"play_binaural(285, 287);",
+      "data_stop":"stop_binaural();",
+      "data_id":"h18zpydhl"
+   },
+   {
       "data_name":"2.4 hz Binaural Beats over Solfeggio 285 hz",
       "data_description":"Binaural beats for deep sleep [Phase 1]. Heal tissues while sleeping.",
       "data_start":"play_binaural(285, 287.4);",

--- a/json/binaurals.json
+++ b/json/binaurals.json
@@ -184,7 +184,7 @@
    {
       "data_name":"2 hz Binaural Beats over Solfeggio 174 hz",
       "data_description":"Nerve regeneration [Phase 0]",
-      "data_start":"play_binaural(174, 214);",
+      "data_start":"play_binaural(174, 176);",
       "data_stop":"stop_binaural();",
       "data_id":"h18zpydhk"
    },

--- a/json/binaurals.json
+++ b/json/binaurals.json
@@ -183,14 +183,14 @@
    },
    {
       "data_name":"2 hz Binaural Beats over Solfeggio 174 hz",
-      "data_description":"Nerve regeneration [Phase 0]",
+      "data_description":"Binaural beats for Nerve regeneration [Phase 0]",
       "data_start":"play_binaural(174, 176);",
       "data_stop":"stop_binaural();",
       "data_id":"h18zpydhk"
    },
    {
       "data_name":"2 hz Binaural Beats over Solfeggio 285 hz",
-      "data_description":"Nerve regeneration [Phase 1]",
+      "data_description":"Binaural beats for Nerve regeneration [Phase 1]",
       "data_start":"play_binaural(285, 287);",
       "data_stop":"stop_binaural();",
       "data_id":"h18zpydhl"

--- a/json/binaurals.json
+++ b/json/binaurals.json
@@ -182,6 +182,13 @@
       "data_id":"h18zpydhj"
    },
    {
+      "data_name":"2 hz Binaural Beats over Solfeggio 174 hz",
+      "data_description":"Nerve regeneration [Phase 0]",
+      "data_start":"play_binaural(174, 214);",
+      "data_stop":"stop_binaural();",
+      "data_id":"h18zpydhk"
+   },
+   {
       "data_name":"2.4 hz Binaural Beats over Solfeggio 285 hz",
       "data_description":"Binaural beats for deep sleep [Phase 1]. Heal tissues while sleeping.",
       "data_start":"play_binaural(285, 287.4);",

--- a/json/dreamachines.json
+++ b/json/dreamachines.json
@@ -114,7 +114,7 @@
    {
      "data_name": "6 hz Dreamachine Beats",
      "data_description": "Dreamachine beats for reduction in unwillingness to do work due to past memories. Must be used during sleep otherwise it may bring in depression and confusion. Typically it is designed to bring your mind to a more relaxed states which if listened too much (around 12 hours) being awake could cause undesired effects. For getting out of hypnosis and bringing clarity. For active learning and retention. ",
-     "data_start": "start_dreamachine(417, 423);",
+     "data_start": "start_dreamachine(6);",
      "data_stop": "stop_dreamachine();",
      "data_id": "oi53lioo6"
    },

--- a/json/dreamachines.json
+++ b/json/dreamachines.json
@@ -70,6 +70,13 @@
      "data_id": "j5arlnle5"
    },
    {
+    "data_name": "2 hz Dreamachine Beats",
+    "data_description": "Dreamachine beats for nerve regeneration.",
+    "data_start": "start_dreamachine(2);",
+    "data_stop": "stop_dreamachine();",
+    "data_id": "j5arlnle6"
+   },
+   {
      "data_name": "2.4 hz Dreamachine Beats",
      "data_description": "Dreamachine beats for deep. Heal tissues while sleeping.",
      "data_start": "start_dreamachine(2.4);",

--- a/json/isochronic.json
+++ b/json/isochronic.json
@@ -182,6 +182,20 @@
       "data_id": "jebx25mao"
     },
     {
+      "data_name": "2 hz Isochronic Tone over Solfeggio 174 hz",
+      "data_description": "Isochronic Tone for nerve regeneration [Phase 0].",
+      "data_start": "play_isochronic(174, 176);",
+      "data_stop": "stop_isochronic();",
+      "data_id": "jebx25map"
+    },
+    {
+      "data_name": "2 hz Isochronic Tone over Solfeggio 285 hz",
+      "data_description": "Isochronic Tone for nerve regeneration [Phase 1].",
+      "data_start": "play_isochronic(285, 287);",
+      "data_stop": "stop_isochronic();",
+      "data_id": "jebx25maq"
+    },
+    {
       "data_name": "2.4 hz Isochronic Tone over Solfeggio 285 hz",
       "data_description": "Isochronic Tone for deep sleep [Phase 1]. Heal tissues while sleeping.",
       "data_start": "play_isochronic(285, 287.4);",

--- a/json/monaurals.json
+++ b/json/monaurals.json
@@ -189,6 +189,13 @@
       "data_id":"ezlajbvzv"
    },
    {
+      "data_name":"2 hz Monaural Beats over Solfeggio 285 hz",
+      "data_description":"Monaural beats for Nerve regeneration [Phase 1]",
+      "data_start":"play_monaural(285, 287);",
+      "data_stop":"stop_monaural();",
+      "data_id":"ezlajbvzw"
+   },
+   {
       "data_name":"2.4 hz Monaural Beats over Solfeggio 285 hz",
       "data_description":"Monaural beats for deep sleep [Phase 1]. Heal tissues while sleeping.",
       "data_start":"play_monaural(285, 287.4);",

--- a/json/monaurals.json
+++ b/json/monaurals.json
@@ -182,6 +182,13 @@
       "data_id":"ezlajbvzt"
    },
    {
+      "data_name":"2 hz Monaural Beats over Solfeggio 174 hz",
+      "data_description":"Monaural beats for Nerve regeneration [Phase 0]",
+      "data_start":"play_monaural(174, 176);",
+      "data_stop":"stop_monaural();",
+      "data_id":"ezlajbvzv"
+   },
+   {
       "data_name":"2.4 hz Monaural Beats over Solfeggio 285 hz",
       "data_description":"Monaural beats for deep sleep [Phase 1]. Heal tissues while sleeping.",
       "data_start":"play_monaural(285, 287.4);",

--- a/json/sq_monaurals.json
+++ b/json/sq_monaurals.json
@@ -183,6 +183,13 @@
       "data_id":"u8vla4bag"
    },
    {
+      "data_name":"2 hz Square Wave Monaural Beats over Solfeggio 174 hz",
+      "data_description":"Square Wave Monaural Beats for Nerve Regeneration [Phase 0].",
+      "data_start":"play_sq_monaural(174, 176);",
+      "data_stop":"stop_sq_monaural();",
+      "data_id":"u8vla4bah"
+   },
+   {
       "data_name":"2.4 hz Square Wave Monaural Beats over Solfeggio 285 hz",
       "data_description":"Square Wave Monaural Beats for deep sleep [Phase 1]. Heal tissues while sleeping.",
       "data_start":"play_sq_monaural(285, 287.4);",

--- a/json/sq_monaurals.json
+++ b/json/sq_monaurals.json
@@ -190,6 +190,13 @@
       "data_id":"u8vla4bah"
    },
    {
+      "data_name":"2 hz Square Wave Monaural Beats over Solfeggio 285 hz",
+      "data_description":"Square Wave Monaural Beats for Nerve Regeneration [Phase 1].",
+      "data_start":"play_sq_monaural(285, 287);",
+      "data_stop":"stop_sq_monaural();",
+      "data_id":"u8vla4bai"
+   },
+   {
       "data_name":"2.4 hz Square Wave Monaural Beats over Solfeggio 285 hz",
       "data_description":"Square Wave Monaural Beats for deep sleep [Phase 1]. Heal tissues while sleeping.",
       "data_start":"play_sq_monaural(285, 287.4);",


### PR DESCRIPTION
Nerve regeneration presets for dreamachine, isochronic tones, binaural beats, monaural beats and square wave monaural beats.

Also includes bug fix of dreamachine 6 hz 